### PR TITLE
Remove spaces from file name for ICAP

### DIFF
--- a/antivirus.py
+++ b/antivirus.py
@@ -365,7 +365,8 @@ class AntiVirus(ServiceBase):
         try:
             if host.method == ICAP_METHOD:
                 version = host.client.options_respmod() if not host.icap_scan_details.no_version else None
-                results = host.client.scan_data(file_contents, file_name)
+                # Remove spaces from file name when using ICAP
+                results = host.client.scan_data(file_contents, file_name.replace(" ", ""))
             elif host.method == HTTP_METHOD:
                 base_url = f"{HTTP_METHOD}://{host.ip}:{host.port}"
                 # Setting up the POST based on the user's configurations


### PR DESCRIPTION
An issue was experienced using the ESET EFS product where "Bad Message" was being returned seemingly at random upon ICAP scan. After some investigation by their backend team, the issue may be related to spaces existing in file names. This is a potentially temporary solution as they should address it on their end.