### PR TITLE
Only split on space if there is no following bracket

### DIFF
--- a/antivirus.py
+++ b/antivirus.py
@@ -243,7 +243,7 @@ class IcapHostClient(HostClient):
         virus_names: Set[str] = set()
         if "," in virus_name:
             virus_names = {vname.strip() for vname in virus_name.split(",")}
-        elif " " in virus_name:
+        elif " " in virus_name and " (" not in virus_name:
             virus_names = {vname.strip() for vname in virus_name.split(" ")}
         else:
             virus_names = {virus_name}

--- a/tests/test_antivirus.py
+++ b/tests/test_antivirus.py
@@ -51,9 +51,45 @@ def check_section_equality(this, that) -> bool:
             this.heuristic.score_map == that.heuristic.score_map and \
             this.heuristic.signatures == that.heuristic.signatures
 
+        if not result_heuristic_equality:
+            print("The heuristics are not equal:")
+            if this.heuristic.attack_ids != that.heuristic.attack_ids:
+                print("The attack_ids are different:")
+                print(f"{this.heuristic.attack_ids}")
+                print(f"{that.heuristic.attack_ids}")
+            if this.heuristic.frequency != that.heuristic.frequency:
+                print("The frequencies are different:")
+                print(f"{this.heuristic.frequency}")
+                print(f"{that.heuristic.frequency}")
+            if this.heuristic.heur_id != that.heuristic.heur_id:
+                print("The heur_ids are different:")
+                print(f"{this.heuristic.heur_id}")
+                print(f"{that.heuristic.heur_id}")
+            if this.heuristic.score != that.heuristic.score:
+                print("The scores are different:")
+                print(f"{this.heuristic.score}")
+                print(f"{that.heuristic.score}")
+            if this.heuristic.score_map != that.heuristic.score_map:
+                print("The score_maps are different:")
+                print(f"{this.heuristic.score_map}")
+                print(f"{that.heuristic.score_map}")
+            if this.heuristic.signatures != that.heuristic.signatures:
+                print("The signatures are different:")
+                print(f"{this.heuristic.signatures}")
+                print(f"{that.heuristic.signatures}")
+
     elif not this.heuristic and not that.heuristic:
         result_heuristic_equality = True
     else:
+        print("The heuristics are not equal:")
+        if this.heuristic:
+            print(f"{this.heuristic.__dict__}")
+        else:
+            print("this.heuristic is None")
+        if that.heuristic:
+            print(f"{that.heuristic.__dict__}")
+        else:
+            print("that.heuristic is None")
         result_heuristic_equality = False
 
     # Assuming we are given the "root section" at all times, it is safe to say that we don't need to confirm parent
@@ -64,9 +100,45 @@ def check_section_equality(this, that) -> bool:
         this.depth == that.depth and \
         len(this.subsections) == len(that.subsections) and \
         this.title_text == that.title_text and \
-        this.tags == that.tags
+        this.tags == that.tags and \
+        this.auto_collapse == that.auto_collapse
 
     if not current_section_equality:
+        print("The current sections are not equal:")
+        if not result_heuristic_equality:
+            print("The result heuristics are not equal")
+        if this.body != that.body:
+            print("The bodies are different:")
+            print(f"{this.body}")
+            print(f"{that.body}")
+        if this.body_format != that.body_format:
+            print("The body formats are different:")
+            print(f"{this.body_format}")
+            print(f"{that.body_format}")
+        if this.classification != that.classification:
+            print("The classifications are different:")
+            print(f"{this.classifications}")
+            print(f"{that.classifications}")
+        if this.depth != that.depth:
+            print("The depths are different:")
+            print(f"{this.depths}")
+            print(f"{that.depths}")
+        if len(this.subsections) != len(that.subsections):
+            print("The number of subsections are different:")
+            print(f"{len(this.subsections)}")
+            print(f"{len(that.subsections)}")
+        if this.title_text != that.title_text:
+            print("The title texts are different:")
+            print(f"{this.title_text}")
+            print(f"{that.title_text}")
+        if this.tags != that.tags:
+            print("The tags are different:")
+            print(f"{this.tags}")
+            print(f"{that.tags}")
+        if this.auto_collapse != that.auto_collapse:
+            print("The auto_collapse settings are different:")
+            print(f"{this.auto_collapse}")
+            print(f"{that.auto_collapse}")
         return False
 
     for index, subsection in enumerate(this.subsections):
@@ -468,7 +540,11 @@ class TestIcapHostClient:
           "blah identified the file as virus_heur",
           {"av.virus_name": ["virus_heur"],
            "av.heuristic": ["virus_heur"]},
-          2, '{"av_name": "blah", "virus_name": "virus_heur", "scan_result": "suspicious", "av_version": "blah"}'), ])
+          2, '{"av_name": "blah", "virus_name": "virus_heur", "scan_result": "suspicious", "av_version": "blah"}'),
+         ("blah\nX-Virus-ID: virus_heur (HTML)\nblah\nblah", "blah", "virus_heur (HTML)",
+          "blah identified the file as virus_heur (HTML)",
+          {"av.virus_name": ["virus_heur (HTML)"]},
+          1, '{"av_name": "blah", "virus_name": "virus_heur (HTML)", "scan_result": "infected", "av_version": "blah"}'), ])
     def test_icap_host_parse_scan_result(
             icap_result, version, virus_name, expected_section_title, expected_tags, expected_heuristic, expected_body):
         from antivirus import IcapHostClient


### PR DESCRIPTION
An AV was returning a virus name as "Blah.blahblah (HTML)", and the current code was splitting on the space and treating that signature as two signatures when it should be only one.