### PR TITLE
If Generic+space in virus name, don't split on space

### DIFF
--- a/antivirus.py
+++ b/antivirus.py
@@ -243,7 +243,8 @@ class IcapHostClient(HostClient):
         virus_names: Set[str] = set()
         if "," in virus_name:
             virus_names = {vname.strip() for vname in virus_name.split(",")}
-        elif " " in virus_name and " (" not in virus_name:
+        # For cases such as "Blah.blahblah (HTML)" and "Blah.blah/Generic Backdoor"
+        elif " " in virus_name and (" (" not in virus_name and "Generic ".lower() not in virus_name.lower()):
             virus_names = {vname.strip() for vname in virus_name.split(" ")}
         else:
             virus_names = {virus_name}

--- a/tests/test_antivirus.py
+++ b/tests/test_antivirus.py
@@ -544,7 +544,11 @@ class TestIcapHostClient:
          ("blah\nX-Virus-ID: virus_heur (HTML)\nblah\nblah", "blah", "virus_heur (HTML)",
           "blah identified the file as virus_heur (HTML)",
           {"av.virus_name": ["virus_heur (HTML)"]},
-          1, '{"av_name": "blah", "virus_name": "virus_heur (HTML)", "scan_result": "infected", "av_version": "blah"}'), ])
+          1, '{"av_name": "blah", "virus_name": "virus_heur (HTML)", "scan_result": "infected", "av_version": "blah"}'),
+         ("blah\nX-Virus-ID: virus_heur/generic blah\nblah\nblah", "blah", "virus_heur/generic blah",
+          "blah identified the file as virus_heur/generic blah",
+          {"av.virus_name": ["virus_heur/generic blah"]},
+          1, '{"av_name": "blah", "virus_name": "virus_heur/generic blah", "scan_result": "infected", "av_version": "blah"}'), ])
     def test_icap_host_parse_scan_result(
             icap_result, version, virus_name, expected_section_title, expected_tags, expected_heuristic, expected_body):
         from antivirus import IcapHostClient


### PR DESCRIPTION
To handle cases such as "Blah.blah/Generic Blah"